### PR TITLE
Added support for getting remote ip from trusted proxies

### DIFF
--- a/config.php.in
+++ b/config.php.in
@@ -65,6 +65,13 @@ $config['SITE_URL'] = 'http://piler.example.com/';
 
 $config['EXTERNAL_DASHBOARD_URL'] = '';
 
+// IP of proxy servers that are trusted to set the real IP address
+$config['TRUSTED_PROXIES'] = array();
+
+// HTTP header name that contains the real IP address
+// Has to be upper case and - replaced with _
+$config['REAL_IP_HEADER'] = 'X_REAL_IP';
+
 $config['SESSION_EXPIRY'] = 3600;
 $config['DELTA_INDEXER_PERIOD'] = 1800;
 

--- a/webui/Zend/Mail.php
+++ b/webui/Zend/Mail.php
@@ -1102,10 +1102,11 @@ class Zend_Mail extends Zend_Mime_Message
 
         $time = time();
 
+        $ipaddr = getRemoteAddr();
         if ($this->_from !== null) {
             $user = $this->_from;
-        } elseif (isset($_SERVER['REMOTE_ADDR'])) {
-            $user = $_SERVER['REMOTE_ADDR'];
+        } elseif ($ipaddr != '') {
+            $user = $ipaddr;
         } else {
             $user = getmypid();
         }

--- a/webui/index.php
+++ b/webui/index.php
@@ -82,10 +82,10 @@ else if(Registry::get('username')) {
    }
 
    if(ENABLE_SAAS == 1) {
-      $query = $db->query("UPDATE " . TABLE_ONLINE . " SET last_activity=? WHERE username=? AND ipaddr=?", array(NOW, $session->get('email'), $_SERVER['REMOTE_ADDR']));
+      $query = $db->query("UPDATE " . TABLE_ONLINE . " SET last_activity=? WHERE username=? AND ipaddr=?", array(NOW, $session->get('email'), getRemoteAddr()));
 
       if($db->countAffected() == 0) {
-         $query = $db->query("INSERT INTO " . TABLE_ONLINE . " (username, ts, last_activity, ipaddr) VALUES(?,?,?,?)", array($session->get('email'), NOW, NOW, $_SERVER['REMOTE_ADDR']));
+         $query = $db->query("INSERT INTO " . TABLE_ONLINE . " (username, ts, last_activity, ipaddr) VALUES(?,?,?,?)", array($session->get('email'), NOW, NOW, getRemoteAddr()));
       }
    }
 

--- a/webui/model/saas/customer.php
+++ b/webui/model/saas/customer.php
@@ -127,10 +127,10 @@ class ModelSaasCustomer extends Model
    public function online($username = '') {
       if($username == '') { return 0; }
 
-      $query = $this->db->query("INSERT INTO " . TABLE_ONLINE . " (username, ts, last_activity, ipaddr) VALUES(?,?,?,?)", array($username, NOW, NOW, $_SERVER['REMOTE_ADDR']));
+      $query = $this->db->query("INSERT INTO " . TABLE_ONLINE . " (username, ts, last_activity, ipaddr) VALUES(?,?,?,?)", array($username, NOW, NOW, getRemoteAddr()));
 
       if($this->db->countAffected() == 0) {
-         $query = $this->db->query("UPDATE " . TABLE_ONLINE . " SET ts=?, last_activity=? WHERE username=? AND ipaddr=?", array(NOW, NOW, $username, $_SERVER['REMOTE_ADDR']));
+         $query = $this->db->query("UPDATE " . TABLE_ONLINE . " SET ts=?, last_activity=? WHERE username=? AND ipaddr=?", array(NOW, NOW, $username, getRemoteAddr()));
       }
 
       return 1;
@@ -140,7 +140,7 @@ class ModelSaasCustomer extends Model
    public function offline($username = '') {
       if($username == '') { return 0; }
 
-      $query = $this->db->query("DELETE FROM " . TABLE_ONLINE . " WHERE username=? AND ipaddr=?", array($username, $_SERVER['REMOTE_ADDR']));
+      $query = $this->db->query("DELETE FROM " . TABLE_ONLINE . " WHERE username=? AND ipaddr=?", array($username, getRemoteAddr()));
 
       return 1;
    }

--- a/webui/securimage/securimage.php
+++ b/webui/securimage/securimage.php
@@ -735,7 +735,7 @@ class Securimage
     public static function getCaptchaId($new = true, array $options = array())
     {
         if (is_null($new) || (bool)$new == true) {
-            $id = sha1(uniqid($_SERVER['REMOTE_ADDR'], true));
+            $id = sha1(uniqid(getRemoteAddr(), true));
             $opts = array('no_session'    => true,
                           'use_database'  => true);
             if (sizeof($options) > 0) $opts = array_merge($options, $opts);
@@ -1588,7 +1588,7 @@ class Securimage
 
         if ($this->use_database && $this->pdo_conn) {
             $id = $this->getCaptchaId(false);
-            $ip = $_SERVER['REMOTE_ADDR'];
+            $ip = getRemoteAddr();
 
             if (empty($id)) {
                 $id = $ip;
@@ -1820,7 +1820,7 @@ class Securimage
                 $stmt   = $this->pdo_conn->prepare($query);
                 $result = $stmt->execute(array(Securimage::$_captchaId));
             } else {
-                $ip = $_SERVER['REMOTE_ADDR'];
+                $ip = getRemoteAddr();
                 $ns = $this->namespace;
 
                 // ip is stored in id column when no captchaId
@@ -1856,7 +1856,7 @@ class Securimage
     protected function clearCodeFromDatabase()
     {
         if ($this->pdo_conn) {
-            $ip = $_SERVER['REMOTE_ADDR'];
+            $ip = getRemoteAddr();
             $ns = $this->pdo_conn->quote($this->namespace);
             $id = Securimage::$_captchaId;
 

--- a/webui/system/misc.php
+++ b/webui/system/misc.php
@@ -4,13 +4,24 @@ function H($s = '') {
    print htmlentities($s);
 }
 
+function getRemoteAddr() {
+   if(count(TRUSTED_PROXIES) > 0 && in_array($_SERVER['REMOTE_ADDR'], TRUSTED_PROXIES) && isset($_SERVER['HTTP_'.REAL_IP_HEADER])) {
+      return $_SERVER['HTTP_'.REAL_IP_HEADER];
+   }
+
+   if(isset($_SERVER['REMOTE_ADDR'])) {
+      return $_SERVER['REMOTE_ADDR'];
+   }
+
+   return '';
+}
 
 function LOGGER($event = '', $username = '') {
    $ipaddr = '';
 
    if($event == "") { return 0; }
 
-   if(isset($_SERVER['REMOTE_ADDR'])) { $ipaddr = $_SERVER['REMOTE_ADDR']; }
+   $ipaddr = getRemoteAddr();
 
    $session = Registry::get('session');
 
@@ -29,7 +40,7 @@ function AUDIT($action = 0, $email = '', $ipaddr = '', $id = 0, $description = '
 
    $session = Registry::get('session');
 
-   if($ipaddr == '' && isset($_SERVER['REMOTE_ADDR'])) { $ipaddr = $_SERVER['REMOTE_ADDR']; }
+   if($ipaddr == '') { $ipaddr = getRemoteAddr(); }
    if($email == '') { $email = $session->get("email"); }
 
    $a = explode("@", $email);


### PR DESCRIPTION
In the config you can set `$config['TRUSTED_PROXIES']` to an array of ip addresses which should be trusted to get the real ip from.
If enabled the the real ip will be extracted from the x-real-ip header. The header to use can be set by `$config['REAL_IP_HEADER']`. The real ip will then be shown in the audit log and in the syslog.