### PR TITLE
Added config option to set recipient delimiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,17 @@ unit_tests/check_parser
 unit_tests/check_parser_utils
 unit_tests/check_rules
 unit_tests/smtp
+config.log
+config.status
+etc/piler.conf
+init.d/rc.piler
+init.d/rc.searchd
+params.h
+piler-config.h
+stamp-h1
+util/import.sh
+util/indexer.attachment.sh
+util/indexer.delta.sh
+util/indexer.main.sh
+util/postinstall.sh
+webui/config.php

--- a/etc/example.conf
+++ b/etc/example.conf
@@ -278,3 +278,11 @@ max_smtp_memory=500000000
 ; When connecting to imap server whether to verify (1) the
 ; SSL/TLS certificate or not (1)
 verifyssl=1
+
+; Recipient delimiter for email addresses.
+; Set of characters that can separate an email address localpart and user name.
+;
+; Examples:
+; When set to "+": aaa+bbb@ccc.fu will be translated to aaa@ccc.fu
+; When set to "+-": aaa+bbb@ccc.fu and aaa-bbb@ccc.fu will be translated to aaa@ccc.fu
+recipient_delimiter=+

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -106,6 +106,7 @@ struct _parse_rule config_parse_rules[] =
    { "verbosity", "integer", (void*) int_parser, offsetof(struct config, verbosity), "1", sizeof(int)},
    { "verifyssl", "integer", (void*) int_parser, offsetof(struct config, verifyssl), "1", sizeof(int)},
    { "workdir", "string", (void*) string_parser, offsetof(struct config, workdir), WORK_DIR, MAXVAL-1},
+   { "recipient_delimiter", "string", (void*) string_parser, offsetof(struct config, recipient_delimiter), "+", MAXVAL-1},
 
    {NULL, NULL, NULL, 0, 0, 0}
 };

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -109,6 +109,8 @@ struct config {
    uint64 max_smtp_memory;
 
    int verifyssl;
+
+   char recipient_delimiter[MAXVAL];
 };
 
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -34,7 +34,7 @@ char *determine_attachment_type(char *filename, char *type);
 char *get_attachment_extractor_by_filename(char *filename);
 void parse_reference(struct parser_state *state, char *s);
 int base64_decode_attachment_buffer(char *p, unsigned char *b, int blen);
-void fix_plus_sign_in_email_address(char *puf, char **at_sign, unsigned int *len);
+void fix_recipient_delimiter_in_email_address(char *puf, char **at_sign, unsigned int *len, char *delimiter);
 void tokenize(char *buf, struct parser_state *state, struct session_data *sdata, struct data *data, struct config *cfg);
 void flush_attachment_buffer(struct parser_state *state, char *abuffer, unsigned int abuffersize);
 void fill_attachment_name_buf(struct parser_state *state, char *buf);

--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -1055,16 +1055,19 @@ int base64_decode_attachment_buffer(char *p, unsigned char *b, int blen){
 }
 
 
-void fix_plus_sign_in_email_address(char *puf, char **at_sign, unsigned int *len){
+void fix_recipient_delimiter_in_email_address(char *puf, char **at_sign, unsigned int *len, char *delimiter){
    char *r;
 
-   r = strchr(puf, '+');
-   if(r){
-      int n = strlen(*at_sign);
-      memmove(r, *at_sign, n);
-      *(r+n) = '\0';
-      *len = strlen(puf);
-      *at_sign = r;
+   // loop over configured delimiters since there may be multiple delimiters configured
+   for(; *delimiter; delimiter++){
+      r = strchr(puf, *delimiter);
+      if(r){
+         int n = strlen(*at_sign);
+         memmove(r, *at_sign, n);
+         *(r+n) = '\0';
+         *len = strlen(puf);
+         *at_sign = r;
+      }
    }
 }
 

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -56,7 +56,7 @@ void tokenize(char *buf, struct parser_state *state, struct session_data *sdata,
          strtolower(puf);
 
          q = strchr(puf, '@');
-         if(q) fix_plus_sign_in_email_address(puf, &q, &len);
+         if(q) fix_recipient_delimiter_in_email_address(puf, &q, &len, cfg->recipient_delimiter);
 
          memcpy(&(state->b_from[strlen(state->b_from)]), puf, len);
 
@@ -86,7 +86,7 @@ void tokenize(char *buf, struct parser_state *state, struct session_data *sdata,
          strtolower(puf);
 
          q = strchr(puf, '@');
-         if(q) fix_plus_sign_in_email_address(puf, &q, &len);
+         if(q) fix_recipient_delimiter_in_email_address(puf, &q, &len, cfg->recipient_delimiter);
 
          memcpy(&(state->b_sender[strlen(state->b_sender)]), puf, len);
 
@@ -110,8 +110,9 @@ void tokenize(char *buf, struct parser_state *state, struct session_data *sdata,
          strtolower(puf);
 
          /* fix aaa+bbb@ccc.fu address to aaa@ccc.fu, 2017.02.04, SJ */
+         /* recipient_delimiter (+ by default) can be configured to multiple chars on some mail systems, 2025.03.24, PM */
          q = strchr(puf, '@');
-         if(q) fix_plus_sign_in_email_address(puf, &q, &len);
+         if(q) fix_recipient_delimiter_in_email_address(puf, &q, &len, cfg->recipient_delimiter);
 
          if((state->message_state == MSG_RECIPIENT || state->message_state == MSG_ENVELOPE_TO) && findnode(state->journal_recipient, puf) == NULL && state->journaltolen < sizeof(state->b_journal_to)-len-1){
             addnode(state->journal_recipient, puf);


### PR DESCRIPTION
Some mail systems use different recipient delimiters to separate an email address localpart from the user name.
This PR changes makes it possible to configure one or multiple delimierts, according to the config of the used mail system.

The delimiter can be set by `recipient_delimiter=+` in `piler.conf`. Default is `+` (like before without this config option).

Examples:
* When set to `+`:  
`aaa+bbb@ccc.fu` will be translated to `aaa@ccc.fu`
* When set to `+-`:  
`aaa+bbb@ccc.fu` and `aaa-bbb@ccc.fu` will be translated to `aaa@ccc.fu`