### PR TITLE
Dockerfile: Cleanup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,9 +18,11 @@ COPY ${PACKAGE}_${TARGETARCH}.deb /
 RUN userdel -r ubuntu && \
     apt-get update && \
     apt-get -y --no-install-recommends install \
-       wget openssl sysstat php8.3-cli php8.3-cgi php8.3-mysql php8.3-fpm php8.3-zip php8.3-ldap \
-       php8.3-gd php8.3-curl php8.3-xml php8.3-memcached catdoc unrtf poppler-utils nginx tnef sudo libzip4t64 \
-       libtre5 cron libmariadb-dev mariadb-client-core python3 python3-mysqldb ca-certificates curl rsyslog gnupg && \
+       wget openssl sysstat php-cli php-cgi php-mysql php-fpm php-zip php-ldap \
+       php-gd php-curl php-xml php-memcached catdoc unrtf poppler-utils \
+       nginx tnef sudo libzip4t64 libtre5 cron \
+       mariadb-client-core python3 python3-mysqldb \
+       ca-certificates curl rsyslog gnupg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i '/session    required     pam_loginuid.so/c\#session    required     pam_loginuid.so' /etc/pam.d/cron && \


### PR DESCRIPTION
Sync with instructions in README:
- apply https://github.com/jsuto/piler/commit/6009bb063e390abf004f4821e55acb379d0e92bc
- apply https://github.com/jsuto/piler/commit/1623bbf3a2abbc4d73982c6f4066f62d393d1711

I did also use same structure to list deps for easier comparisons and updates.

One discrepancy I noticed:
README lists `mariadb-server` as well, while the Dockerfile does not.