### PR TITLE
Fixed redirect URL for enable_purge toggle

### DIFF
--- a/webui/controller/health/health.php
+++ b/webui/controller/health/health.php
@@ -31,7 +31,7 @@ class ControllerHealthHealth extends Controller {
       else {
          if(isset($_GET['toggle_enable_purge'])) {
             $this->model_health_health->toggle_option('enable_purge');
-            header('Location: ' . SITE_URL . HEALTH_URL);
+            header('Location: ' . SITE_URL . 'index.php?route=health/health');
             exit;
          }
 


### PR DESCRIPTION
HEALTH_URL already include SITE_URL, so the location header contained SITE_URL twice.
Using index.php?route=... as used in similar situations. 