### PR TITLE
Change log level for sphinx queries to debug

### DIFF
--- a/webui/system/database/sphinx.php
+++ b/webui/system/database/sphinx.php
@@ -84,7 +84,7 @@ class Sphinx {
          if($v[0] == "total_found") { $query->total_found = $v[1]; }
       }
 
-      if(LOG_LEVEL >= NORMAL) { syslog(LOG_INFO, sprintf("sphinx query: '%s' in %.2f s, %d hits, %d total found", $query->query, $query->exec_time, $query->num_rows, $query->total_found)); }
+      if(LOG_LEVEL >= DEBUG) { syslog(LOG_INFO, sprintf("sphinx query: '%s' in %.2f s, %d hits, %d total found", $query->query, $query->exec_time, $query->num_rows, $query->total_found)); }
 
       return $query;
    }


### PR DESCRIPTION
**Describe the bug**
The mail log gets filled with unncessary log messages like this when a search is run:
````
sphinx query: 'SELECT mid, tag FROM tag1 WHERE uid=1
````

IMHO, this should only be written when the loglevel is set to debug, but according to https://github.com/jsuto/piler/blob/224c554841d5b41f648bb1b97b4315d4d32ccf05/webui/system/database/sphinx.php#L87C1-L88C1 it is already written at "normal" loglevel. Afaics, there is no other loglevel, so I cannot tone this down (and I still want to have normal logging).

This PR changes the log level for those queries to debug.
