### PR TITLE
Fix missing $ for $config

### DIFF
--- a/util/postinstall.sh.in
+++ b/util/postinstall.sh.in
@@ -400,12 +400,12 @@ execute_post_install_tasks() {
 
 \$config['SITE_NAME'] = '$HOSTNAME';
 \$config['PATH_PREFIX'] = '/';
-\$config['SITE_URL'] = 'http://' . config['SITE_NAME'] . config['PATH_PREFIX'];
+\$config['SITE_URL'] = 'http://' . \$config['SITE_NAME'] . \$config['PATH_PREFIX'];
 \$config['DIR_BASE'] = '$DOCROOT/';
 
 \$config['SMTP_DOMAIN'] = '$HOSTNAME';
-\$config['SMTP_FROMADDR'] = 'no-reply@' . config['SMTP_DOMAIN'];
-\$config['ADMIN_EMAIL'] = 'admin@' . config['SMTP_DOMAIN'];
+\$config['SMTP_FROMADDR'] = 'no-reply@' . \$config['SMTP_DOMAIN'];
+\$config['ADMIN_EMAIL'] = 'admin@' . \$config['SMTP_DOMAIN'];
 
 \$config['DB_DRIVER'] = 'mysql';
 \$config['DB_PREFIX'] = '';


### PR DESCRIPTION
Fixes the following
 _Originally posted by @larsen0815 in [#348](https://github.com/jsuto/piler/issues/348#issuecomment-3648402471)_

> **11)** config-site.php is looking much better now, but three lines need `$config` instead of `config` (four occurences) to prevent error `Undefined constant "config" in /etc/piler/config-site.php`
> ````
> $config['SITE_URL'] = 'http://' . config['SITE_NAME'] . config['PATH_PREFIX'];
> $config['SMTP_FROMADDR'] = 'no-reply@' . config['SMTP_DOMAIN'];
> $config['ADMIN_EMAIL'] = 'admin@' . config['SMTP_DOMAIN'];
> ````
