### PR TITLE
Use exit code 0 when stopping piler-smtp

### DIFF
--- a/src/piler-smtp.c
+++ b/src/piler-smtp.c
@@ -76,7 +76,7 @@ void p_clean_exit(int sig){
 
    ERR_free_strings();
 
-   exit(1);
+   exit(0);
 }
 
 


### PR DESCRIPTION
Same as in https://github.com/jsuto/piler/issues/349
When the piler-smtp service is stopped, it's shown as failed.