### PR TITLE
Add dependencies to DEB package

### DIFF
--- a/build/run.sh
+++ b/build/run.sh
@@ -53,6 +53,20 @@ make_deb_package() {
       -v "${VERSION}-${DISTRO}" \
       --iteration "${COMMIT_ID}${DEBUG_SUFFIX}" \
       --description "$description" \
+      --depends catdoc \
+      --depends libtre5 \
+      --depends php-curl \
+      --depends php-fpm \
+      --depends php-gd \
+      --depends php-ldap \
+      --depends php-mysql \
+      --depends php-xml \
+      --depends php-zip \
+      --depends poppler-utils \
+      --depends python3 \
+      --depends python3-mysqldb \
+      --depends tnef \
+      --depends unrtf \
       --before-install "${REPO_ROOT}/build/fpm-${project}-before-install.sh" \
       --after-install "${REPO_ROOT}/build/fpm-${project}-after-install.sh"
 


### PR DESCRIPTION
Fixes
 _Originally posted by @larsen0815 in [#348](https://github.com/jsuto/piler/issues/348#issuecomment-3648402471)_

> **1)**
> Wouldn't it be possible to have the deb package require these, so apt can automatically install the packages?

Installation should be done by apt then to automatically install dependencies. dpkg will complain about missing packages so the user has to manually install them.
````
apt piler_1.4.8-noble-d3460835_amd64.deb
````

I left out some other dependencies like cron, rsyslog, etc. and all the dev packages.
