### PR TITLE
Empty default text "Which browsers are supported" on login page

### DIFF
--- a/config.php.in
+++ b/config.php.in
@@ -32,7 +32,7 @@ $config['BRANDING_TEXT'] = '';
 $config['BRANDING_URL'] = '';
 $config['BRANDING_LOGO'] = '/assets/images/archive-logo-sm.png';
 
-$config['COMPATIBILITY'] = 'Which browsers are supported, etc';
+$config['LOGIN_EXTRA_NOTES'] = '';
 
 $config['PREVIEW_PANE'] = 1; // 0: display message in a fullscreen modal
 $config['FULL_GUI'] = 1;

--- a/contrib/proxmox-lxc/mailpiler.orig
+++ b/contrib/proxmox-lxc/mailpiler.orig
@@ -119,7 +119,7 @@ cat >> /usr/local/etc/piler/config-site.php <<EOF
 // CUSTOM
 \$config['PROVIDED_BY'] = '$PILER_DOM';
 \$config['SUPPORT_LINK'] = 'https://$PILER_DOM';
-\$config['COMPATIBILITY'] = '';
+\$config['LOGIN_EXTRA_NOTES'] = '';
 
 // fancy features.
 \$config['ENABLE_INSTANT_SEARCH'] = 1;

--- a/webui/templates/login/login.tpl
+++ b/webui/templates/login/login.tpl
@@ -60,7 +60,7 @@
                <p><a href="<?php print $auth_url; ?>"><?php print $text_login_via_google; ?></a></p>
             <?php } ?>
 
-              <p><?php print COMPATIBILITY; ?></p>
+              <p><?php print LOGIN_EXTRA_NOTES; ?></p>
             </div>
             <div class="col"></div>
           </div>


### PR DESCRIPTION
Fixes #391 
Also changed the config variable's name as requested (from COMPATIBILITY to LOGIN_EXTRA_NOTES)