### PR TITLE
Use correct result code for "discarding by archiving policy"

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -90,7 +90,7 @@ int import_message(struct session_data *sdata, struct data *data, struct counter
 
    if(rule){
       if(data->quiet == 0) printf("discarding %s by archiving policy: %s\n", data->import->filename, rule);
-      rc = OK;
+      rc = ERR_DISCARDED;
    }
    else {
       make_digests(sdata, cfg);


### PR DESCRIPTION
pilerimport didn't log the number of discarded emails to syslog. The text always was "discarded=0" no matter how many emails were discarded.

I'm pretty sure I got the correct line which should fix it. Wasn't able to test this. Not sure if this might have any side-effects as I don't know the code.