### PR TITLE
Add AppArmor parameter to be able to run docker command in LXC

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Clone the repo, and the following command in the repo root:
 
 ```
       docker run --rm \
+           --security-opt apparmor=unconfined \
            -e PROJECT_ID=piler \
            -e DISTRO=noble \
            -e ARCH=amd64 \


### PR DESCRIPTION
This PR adds the appropriate parameter to the docker command to avoid this error:
````
docker: Error response from daemon: AppArmor enabled on system but the docker-default profile could not be loaded: running '/usr/sbin/apparmor_parser -Kr /var/lib/docker/tmp/docker-default3121790609' failed with output: apparmor_parser: Unable to replace "docker-default".  apparmor_parser: Access denied. You need policy admin privileges to manage profiles.
error: exit status 243
````
