### PR TITLE
Use cursor keys left/right to go through search result pages

### DIFF
--- a/webui/assets/js/piler.js
+++ b/webui/assets/js/piler.js
@@ -955,17 +955,18 @@ let Piler =
               Piler.show_next_message();
            }
 
-           // 37: left, 39: right
+           // 37: left, go to previous page
            if(e.keyCode == 37){
               e.preventDefault();
-              //TODO check if navigation function already prevents going negative or max+1
-              //TODO create getCurrentPage()
-              Piler.navigation(getCurrentPage() - 1);
+              if(Piler.Shared.page > 1) {
+                 Piler.navigation(Piler.Shared.page - 1);
+              }
            }
 
+           // 39: right, go to next page
            if(e.keyCode == 39){
               e.preventDefault();
-              Piler.navigation(getCurrentPage() + 1);
+              Piler.navigation(Piler.Shared.page + 1);
            }
         });
 


### PR DESCRIPTION
In #381, you recently added the possibility to go through mails by cursor keys up/down. This PR should do the same for left/right: Go to the previous/next page of search results.

The user could then easily go through all mails and pages just using the cursor keys.

However, **this is just a draft**. I am not a web dev and ChatGPT wasn't able to create working code to detect the current page.
If you could plese tell me how to solve this, I would update the PR accordingly.
