### PR TITLE
Move button "Apply changes" to the top

### DIFF
--- a/webui/templates/policy/exclusion.tpl
+++ b/webui/templates/policy/exclusion.tpl
@@ -163,6 +163,9 @@
           <button type="reset" class="btn btn-secondary"><?php print $text_cancel; ?></button>
         </div>
         <div class="col-auto">
+          <button type="button" class="btn btn-danger" onclick="Piler.reload_piler();"><?php print $text_apply_changes; ?></button>
+        </div>
+        <div class="col-auto">
           <span id="help1" class="form-text"></span>
         </div>
       </div>
@@ -214,9 +217,4 @@
 
     </div>
   </div>
-</div>
-
-
-<div>
-  <button type="button" class="btn btn-danger" onclick="Piler.reload_piler();"><?php print $text_apply_changes; ?></button>
 </div>

--- a/webui/templates/policy/folder.tpl
+++ b/webui/templates/policy/folder.tpl
@@ -195,6 +195,9 @@
           <button type="reset" class="btn btn-secondary"><?php print $text_cancel; ?></button>
         </div>
         <div class="col-auto">
+          <button type="button" class="btn btn-danger" onclick="Piler.reload_piler();"><?php print $text_apply_changes; ?></button>
+        </div>
+        <div class="col-auto">
           <span id="help1" class="form-text"></span>
         </div>
       </div>
@@ -254,9 +257,4 @@
 
     </div>
   </div>
-</div>
-
-
-<div>
-  <button type="button" class="btn btn-danger" onclick="Piler.reload_piler();"><?php print $text_apply_changes; ?></button>
 </div>

--- a/webui/templates/policy/retention.tpl
+++ b/webui/templates/policy/retention.tpl
@@ -190,6 +190,9 @@
           <button type="reset" class="btn btn-secondary"><?php print $text_cancel; ?></button>
         </div>
         <div class="col-auto">
+          <button type="button" class="btn btn-danger" onclick="Piler.reload_piler();"><?php print $text_apply_changes; ?></button>
+        </div>
+        <div class="col-auto">
           <span id="help1" class="form-text"></span>
         </div>
       </div>
@@ -255,9 +258,4 @@
 
     </div>
   </div>
-</div>
-
-
-<div>
-  <button type="button" class="btn btn-danger" onclick="Piler.reload_piler();"><?php print $text_apply_changes; ?></button>
 </div>


### PR DESCRIPTION
When there are many entries in the list, the button is not visible without scrolling and the user might forget to apply the changes after having added another item.

This PR moves the button to the top next to the others while keeping a distance to the Cancel button.
