### PR TITLE
Added glob pattern support to imapfetch.py skiplist

### DIFF
--- a/util/imapfetch.py
+++ b/util/imapfetch.py
@@ -4,6 +4,7 @@
 import MySQLdb as dbapi
 import argparse
 import configparser
+import fnmatch
 import imaplib
 import os
 import re
@@ -58,7 +59,7 @@ def read_folder_list(conn):
             f = re.split(r' \"[\/\.\\]+\" ', folder)
             result.append(f[1])
 
-    return [x for x in result if x not in opts['skip_folders']]
+    return [x for x in result if not any(fnmatch.fnmatch(x.lower(), p.lower()) for p in opts['skip_folders'])]
 
 
 def process_folder(conn, folder):


### PR DESCRIPTION
Fixes #413

With this change, the -x / --skip-list option now supports glob patterns via fnmatch. Examples:

- -x "shared/*" — skips shared/aaa, shared/bbb/ccc, etc.
- -x "shared/*,junk,trash" — combines prefix exclusion with exact names
- -x "shared*" — skips shared, shared/aaa, sharedstuff, etc.
- -x "junk" — still works as before (exact match is a valid glob pattern)
                                                                         
The matching is case-insensitive to handle servers that return folder names in varying case.