### PR TITLE
Maximize preview pane

### DIFF
--- a/webui/assets/css/piler.css
+++ b/webui/assets/css/piler.css
@@ -19,6 +19,7 @@ a.dropdown-item {font-weight:100; text-decoration:none;}
 .resizer { height: 5px; background: #333; cursor: row-resize; }
 .pane-upper-content { height: calc(100% - 40px); /* 40px is the height of the fixed bottom row in the upper pane */ overflow-y: auto; border: 1px solid #ccc;}
 .pane-upper-fixed { height: 40px; background: #f1f1f1; position: absolute; bottom: 0; width: 100%; border-top: 1px solid #ddd; }
+.pane-lower { min-height: calc(95vh) }
 #preview {height: 500px; border: 1px solid #ccc;}
 .no-select { user-select: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; }
 


### PR DESCRIPTION
The preview pane is a little bit too large, so when no mail is displayed, it is possible to scroll a little bit.
This commit fixes the preview pane's height.