### PR TITLE
Some more fixes for decoding of headers

### DIFF
--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -421,16 +421,14 @@ void fixupEncodedHeaderLine(char *buf, int buflen){
                snprintf(encoding, sizeof(encoding)-1, "%s", p);
                *e = '?';
 
-               s = strcasestr(e, "?B?");
-               if(s){
+               if(strncasecmp(e, "?B?", 3) == 0){
                   b64 = 1;
-                  p = s + 3;
+                  p = e + 3;
                }
                else {
-                  s = strcasestr(e, "?Q?");
-                  if(s){
+                  if(strncasecmp(e, "?Q?", 3) == 0){
                      qp = 1;
-                     p = s + 3;
+                     p = e + 3;
                   }
                }
             }

--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -346,6 +346,17 @@ void fixupEncodedHeaderLine(char *buf, int buflen){
 
    memset(puf, 0, sizeof(puf));
 
+   /*
+    * Replace TAB with SPACE so split_string(q, " ", ...) will also do its
+    * job when header lines are folded with tabs.
+    */
+   q = buf;
+   while(*q){
+      if(*q == '\t')
+         *q = ' ';
+      ++q;
+   }
+
    q = buf;
 
    do {
@@ -361,7 +372,7 @@ void fixupEncodedHeaderLine(char *buf, int buflen){
          r = strstr(q, "=?");
          if(r){
             s = q;
-            while(s < r && (*s == ' ' || *s == '\t'))
+            while(s < r && *s == ' ')
                ++s;
             if(s == r)
                q = r;

--- a/unit_tests/check_parser_utils.c
+++ b/unit_tests/check_parser_utils.c
@@ -160,6 +160,9 @@ static void test_fixupEncodedHeaderLine(){
       {"=?gb2312?B?yc/Gz76pIC0gw7/fTMir0bKy6YjzuOYgKDIwMTcxMDMwLTMxKSBHQlcgUG9k?==?gb2312?Q?ium_&_Basement.docx?=", "上葡京 - 每週全巡查報告 (20171030-31) GBW Podium & Basement.docx"},
       {"Subject: =?UTF-8?Q?=E2=98=85_JubiDu!Versandkost?= =?UTF-8?Q?enfrei-Verl=C3=A4ngerung!=E2=98=85?=", "Subject: ★ JubiDu!Versandkostenfrei-Verlängerung!★"},
       {"Happy New Year! =?utf-8?q?=F0=9F=8E=86?=", "Happy New Year! 🎆"},
+      {"P=?utf-8?B?w6Q=?=chter ohne Augenma=?iso-8859-1?Q?=DF?= sind =?iso-8859-1?Q?=FC?=bel", "Pächter ohne Augenmaß sind übel"},
+      {"=?iso-8859-1?Q?FooBarFoo-AG_=22ABCDEF=22:_Mit_Digitalminister_Hoffmeiser_?=\t=?iso-8859-1?Q?zum_=22EU_Sonder_Gipfel=22_in_Wacken=2C_10._-_22.04.2026_-?=  =?iso-8859-1?Q?_Sitzplatzvergabeverfahren_f=FCr_F=FChrungssta?=\t =?iso-8859-1?Q?b?=", "FooBarFoo-AG \"ABCDEF\": Mit Digitalminister Hoffmeiser zum \"EU Sonder Gipfel\" in Wacken, 10. - 22.04.2026 - Sitzplatzvergabeverfahren für Führungsstab"},
+
    };
 
    TEST_HEADER();


### PR DESCRIPTION
Previous fix #359 didn't handle TABs in folded headers completely.

Found and fixed a bug where a single quoted-printable encoded `b` (e.g. `=?iso-8859-1?Q?b?=`) was mistakenly decoded as base64 encoding, because `strcasestr(e, "?B?")` grabbed the `?b?` instead of testing the `?Q?`. Switched to strncasecmp(...) to make sure only the first 3 characters are compared. Though this sounds weird, it can happen if an encoded header hits the length limit of a single encoded word.

Added testcases for #359 and for TAB folding (plus single encoded `b`)
