### PR TITLE
Use -attime parameter to verify timestamp.

### DIFF
--- a/webui/system/helper/TrustedTimestamps.php
+++ b/webui/system/helper/TrustedTimestamps.php
@@ -229,7 +229,7 @@ class TrustedTimestamps
         if(TSA_RELAXED_CHECK) {
            $relaxed_check = " -no_check_time ";
         } else {
-           $relaxed_check = "";
+           $relaxed_check = " -attime " . escapeshellarg($response_time);
         }
 
         $cmd = OPENSSL_BINARY . " ts -verify -digest " . escapeshellarg($hash) . $relaxed_check . " -in ".escapeshellarg($responsefile)." -CAfile ".escapeshellarg($tsa_cert_file)." -untrusted ".escapeshellarg($untrustedfile);


### PR DESCRIPTION
Timestamp must be verified at the time it was issued, as otherwise verification will fail if the certificate expired in the meantime.

In [d75ce865c45181367cbbb025cc4ce390d94d3394] `TSA_RELAXED_CHECK` was introduced, probably to solve the same issue, but going further by disabling the time check completely using `-no-check_time`. You might want to drop it.