### PR TITLE
Fix searchd connection with newer MariaDB Connector/C

### DIFF
--- a/src/mysql.c
+++ b/src/mysql.c
@@ -39,6 +39,14 @@ int open_sphx(struct session_data *sdata, struct config *cfg){
 
    mysql_init(&(sdata->sphx));
 
+   /*
+    * searchd speaks the MySQL protocol but does not support TLS.
+    * Newer MariaDB Connector/C versions enable server certificate
+    * verification by default, causing mysql_real_connect() to fail.
+    */
+   unsigned int verify = 0;
+   mysql_options(&(sdata->sphx), MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify);
+
    mysql_options(&(sdata->sphx), MYSQL_OPT_CONNECT_TIMEOUT, (const char*)&cfg->mysql_connect_timeout);
    mysql_options(&(sdata->sphx), MYSQL_OPT_RECONNECT, (const char*)&rc);
 


### PR DESCRIPTION
Newer versions of MariaDB Connector/C enable server certificate verification by default. Since Sphinx/Manticore `searchd` (MySQL protocol on port 9306) does not support TLS, `mysql_real_connect()` fails with:

`TLS/SSL error: SSL is required, but the server does not support it`

Disable `MYSQL_OPT_SSL_VERIFY_SERVER_CERT` for the `searchd` connection before calling `mysql_real_connect()`.

This change only affects the Sphinx/searchd connection and does not modify the regular MySQL/MariaDB database connection.

Fixes #474 
