### PR TITLE
imapfetch: quote IMAP mailbox names instead of backslash-escaping spaces

### DIFF
--- a/util/imapfetch.py
+++ b/util/imapfetch.py
@@ -63,8 +63,11 @@ def read_folder_list(conn):
 
 
 def process_folder(conn, folder):
-    # Space in the folder name must be escaped
-    folder = re.sub(r' ', '\\ ', folder)
+    # imaplib sends mailbox names verbatim; quote per RFC 3501 so names with
+    # spaces (e.g. "[Gmail]/All Mail") are one astring. LIST output already
+    # arrives quoted - leave those alone.
+    if not (folder.startswith('"') and folder.endswith('"')):
+        folder = '"' + folder.replace('\\', '\\\\').replace('"', '\\"') + '"'
 
     if opts['verbose']:
         print("Processing {}".format(folder))


### PR DESCRIPTION
imaplib sends command arguments verbatim, so `re.sub(r' ', '\\ ', folder)` in `process_folder` produces

    A3 EXAMINE [Gmail]/All\ Mail

which is not a valid IMAP astring. Gmail rejects it and the folder is skipped with `Error processing folder`. Passing the name pre-quoted (`-f '"[Gmail]/All Mail"'`) fails the same way because the backslash then is inside the quoted string.

This quotes the mailbox name per RFC 3501 (escaping `\` and `"`) unless it already arrived quoted from `LIST`.

Verified against Gmail (`[Gmail]/All Mail`, via `-f`) and mailbox.org (`"House stuff/Exterior Pros"`, via `LIST`) with the 1.4.9 docker image.