### PR TITLE
postinstall: fix key size check to match KEYLEN

### DIFF
--- a/util/postinstall.sh.in
+++ b/util/postinstall.sh.in
@@ -297,7 +297,7 @@ make_cron_entries() {
 make_new_key() {
    if [[ ! -f "$KEYFILE" ]]; then
       dd if=/dev/urandom bs=56 count=1 of="$KEYFILE" 2>/dev/null
-      if [ "$(stat -c '%s' "$KEYFILE")" -ne 64 ]; then echo "could not read 64 bytes from /dev/urandom to ${KEYFILE}"; exit 1; fi
+      if [ "$(stat -c '%s' "$KEYFILE")" -ne 56 ]; then echo "could not read 56 bytes from /dev/urandom to ${KEYFILE}"; exit 1; fi
       chgrp "$PILERUSER" "$KEYFILE"
       chmod 640 "$KEYFILE"
    fi


### PR DESCRIPTION
make_new_key() writes 56 bytes with dd but checks for 64, so the condition can never be satisfied and postinstall always aborts with 'could not read 64 bytes from /dev/urandom'. With set -o errexit it exits before chgrp and chmod, leaving the key as root:root 644.

56 is the correct size: src/config.h defines KEYLEN 56, cfg.h declares key[KEYLEN], and store.c reads exactly KEYLEN bytes. Writing 64 would add 8 bytes the daemon never reads.

The earlier version of the function wrote to $KEYTMPFILE and checked for 56; the size appears to have been changed to 64 when it was reworked to write straight to $KEYFILE.