### PR TITLE
src/Makefile.in: explicit chmod after install to preserve setuid bits

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -94,6 +94,10 @@ install-piler:
 	$(INSTALL) -m 6755 -o $(RUNNING_USER) -g $(RUNNING_GROUP) reindex $(DESTDIR)$(bindir)
 	$(INSTALL) -m 6755 -o $(RUNNING_USER) -g $(RUNNING_GROUP) pilertest $(DESTDIR)$(bindir)
 	$(INSTALL) -m 6755 -o $(RUNNING_USER) -g $(RUNNING_GROUP) pilerstats $(DESTDIR)$(bindir)
+	chmod 6755 $(DESTDIR)$(bindir)/pilerget $(DESTDIR)$(bindir)/pileraget \
+	           $(DESTDIR)$(bindir)/pilerimport $(DESTDIR)$(bindir)/pilerexport \
+	           $(DESTDIR)$(bindir)/reindex $(DESTDIR)$(bindir)/pilertest \
+	           $(DESTDIR)$(bindir)/pilerstats
 
 clean:
 	rm -f *.o *.a libpiler.so* piler pilerconf pilerget pileraget pilerimport pilerexport pilertest pilerstats reindex piler-smtp


### PR DESCRIPTION
install -m 6755 -o USER -g GROUP silently drops the setuid/setgid bits with rust-coreutils, which Ubuntu 26.04 ships as the default /usr/bin/install. It calls chown after chmod, and Linux clears those bits on chown.

Re-applying the mode explicitly makes the build produce working binaries regardless of which install implementation is present.

Refs #490, uutils/coreutils#9134