### PR TITLE
system/request: guard session_start() with session_status()

### DIFF
--- a/webui/system/request.php
+++ b/webui/system/request.php
@@ -27,7 +27,9 @@ class Request {
 class Session {
 
    public function __construct() {
-      session_start();
+      if (session_status() === PHP_SESSION_NONE) {
+         session_start();
+      }
    }
 
 


### PR DESCRIPTION
`Session::__construct()` in `webui/system/request.php` calls `session_start()`
unconditionally:

```php
class Session {
   public function __construct() {
      session_start();
   }
```

When the class is instantiated while a session is already active, PHP logs:

```
PHP Notice: session_start(): Ignoring session_start() because a session is
already active (started from /var/piler/www/system/request.php on line 30)
in /var/piler/www/system/request.php on line 30
```

The file effectively warns about itself, which is confusing when tracking down
session problems.

This happens in piler's own SSO entry point. `webui/sso.php` starts a session
three times in a single request:

```php
session_start();                 // line 2
require_once("config.php");      // line 6 -> config.php:405 does new Session()
$session = new Session();        // line 10
```

Guarding with `session_status()` makes the constructor idempotent. On a fresh
request nothing changes: `session_status()` returns `PHP_SESSION_NONE` and
`session_start()` runs exactly as before.

Environment: piler 1.4.9, PHP 8.5, Ubuntu 26.04.