### PR TITLE
login/login: guard post fields in validate()

### DIFF
--- a/webui/controller/login/login.php
+++ b/webui/controller/login/login.php
@@ -128,7 +128,7 @@ class ControllerLoginLogin extends Controller {
 
    private function validate() {
 
-      if(strlen($this->request->post['username']) < 2){
+      if(strlen($this->request->post['username'] ?? '') < 2){
          $this->error['username'] = $this->data['text_invalid_username'];
       }
 
@@ -137,7 +137,7 @@ class ControllerLoginLogin extends Controller {
          require_once $_SERVER['DOCUMENT_ROOT'] . '/securimage/securimage.php';
          $image = new Securimage();
 
-         if($image->check($this->request->post['captcha']) != true) {
+         if($image->check($this->request->post['captcha'] ?? '') != true) {
             $this->error['captcha'] = 'captcha error';
          }
       }


### PR DESCRIPTION
`ControllerLoginLogin::validate()` reads two POST fields without checking
whether the keys exist:

```php
private function validate() {
   if(strlen($this->request->post['username']) < 2){
      ...
   if($image->check($this->request->post['captcha']) != true) {
```

Any POST request dispatched to this controller without the login form produces
on PHP 8:

```
PHP Warning: Undefined array key "username" in
/var/piler/www/controller/login/login.php on line 131
```

`strlen(null)` is also deprecated since PHP 8.1, so line 131 warns twice on
newer versions.

Treating a missing field as empty keeps the existing behaviour - validation
fails with `text_invalid_username` either way.

The reads at lines 48, 51 and 95 are left alone: they only run after
`validate()` has returned true, so the key is guaranteed to exist.

Verified on a live 1.4.9 install: the warning is gone from the PHP-FPM log for
a POST without form fields, and normal login as well as the empty-username
validation error behave as before.

Environment: piler 1.4.9, PHP 8.5, Ubuntu 26.04, nginx.